### PR TITLE
Support business days

### DIFF
--- a/grammar/en/src/rules_datetime.rs
+++ b/grammar/en/src/rules_datetime.rs
@@ -1105,7 +1105,7 @@ pub fn rules_cycle(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
                       |_| CycleValue::new(Grain::Hour)
     );
     b.rule_1_terminal("day (cycle)",
-                      b.reg(r#"days?"#)?,
+                      b.reg(r#"(?:buss?iness? )?days?"#)?,
                       |_| CycleValue::new(Grain::Day)
     );
     b.rule_1_terminal("week (cycle)",

--- a/grammar/en/src/rules_datetime.rs
+++ b/grammar/en/src/rules_datetime.rs
@@ -1105,7 +1105,7 @@ pub fn rules_cycle(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
                       |_| CycleValue::new(Grain::Hour)
     );
     b.rule_1_terminal("day (cycle)",
-                      b.reg(r#"(?:buss?iness? )?days?"#)?,
+                      b.reg(r#"(?:buss?iness? |work ?|week ?)?days?"#)?,
                       |_| CycleValue::new(Grain::Day)
     );
     b.rule_1_terminal("week (cycle)",

--- a/grammar/en/src/rules_duration.rs
+++ b/grammar/en/src/rules_duration.rs
@@ -18,7 +18,7 @@ pub fn rules_duration(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
                       |_| Ok(UnitOfDurationValue::new(Grain::Hour))
     );
     b.rule_1_terminal("day (unit-of-duration)",
-                      b.reg(r#"days?"#)?,
+                      b.reg(r#"(?:buss?iness?)? days?"#)?,
                       |_| Ok(UnitOfDurationValue::new(Grain::Day))
     );
     b.rule_1_terminal("week (unit-of-duration)",

--- a/grammar/en/src/rules_duration.rs
+++ b/grammar/en/src/rules_duration.rs
@@ -18,7 +18,7 @@ pub fn rules_duration(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
                       |_| Ok(UnitOfDurationValue::new(Grain::Hour))
     );
     b.rule_1_terminal("day (unit-of-duration)",
-                      b.reg(r#"(?:buss?iness?)? days?"#)?,
+                      b.reg(r#"(?:buss?iness? |worki?n?g? ?|week ?)?days?"#)?,
                       |_| Ok(UnitOfDurationValue::new(Grain::Day))
     );
     b.rule_1_terminal("week (unit-of-duration)",

--- a/grammar/es/src/rules_datetime.rs
+++ b/grammar/es/src/rules_datetime.rs
@@ -1131,7 +1131,7 @@ pub fn rules_cycle(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
                       |_| CycleValue::new(Grain::Hour)
     );
     b.rule_1_terminal("day (cycle)",
-                      b.reg(r#"d[iíì]as?"#)?,
+                      b.reg(r#"d[iíì]as?(?: h[aá]b[iíì]le?s?)?"#)?,
                       |_| CycleValue::new(Grain::Day)
     );
     b.rule_1_terminal("week (cycle)",

--- a/grammar/es/src/rules_datetime.rs
+++ b/grammar/es/src/rules_datetime.rs
@@ -1131,7 +1131,7 @@ pub fn rules_cycle(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
                       |_| CycleValue::new(Grain::Hour)
     );
     b.rule_1_terminal("day (cycle)",
-                      b.reg(r#"d[iíì]as?(?: h[aá]b[iíì]le?s?)?"#)?,
+                      b.reg(r#"d[iíì]as?(?: h[aá]b[iíì]le?s?| laborab?les| de trabajo)?"#)?,
                       |_| CycleValue::new(Grain::Day)
     );
     b.rule_1_terminal("week (cycle)",

--- a/grammar/es/src/rules_duration.rs
+++ b/grammar/es/src/rules_duration.rs
@@ -18,7 +18,7 @@ pub fn rules_duration(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
                       |_| Ok(UnitOfDurationValue::new(Grain::Hour))
     );
     b.rule_1_terminal("day (unit-of-duration)",
-                      b.reg(r#"d[iíì]as?"#)?,
+                      b.reg(r#"d[iíì]as?(?: h[aá]b[iíì]le?s?)?"#)?,
                       |_| Ok(UnitOfDurationValue::new(Grain::Day))
     );
     b.rule_1_terminal("week (unit-of-duration)",

--- a/grammar/es/src/rules_duration.rs
+++ b/grammar/es/src/rules_duration.rs
@@ -18,7 +18,7 @@ pub fn rules_duration(b: &mut RuleSetBuilder<Dimension>) -> RustlingResult<()> {
                       |_| Ok(UnitOfDurationValue::new(Grain::Hour))
     );
     b.rule_1_terminal("day (unit-of-duration)",
-                      b.reg(r#"d[iíì]as?(?: h[aá]b[iíì]le?s?)?"#)?,
+                      b.reg(r#"d[iíì]as?(?: h[aá]b[iíì]le?s?| laborab?les| de trabajo)?"#)?,
                       |_| Ok(UnitOfDurationValue::new(Grain::Day))
     );
     b.rule_1_terminal("week (unit-of-duration)",


### PR DESCRIPTION
English:
```
Running `rustling-ontology/target/debug/rustling-cli --lang en parse 'i will get it done in five business days'`
+----+--------------+-----------+------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
| ix | log(p)       | p         | text                                     | Output(OutputValue)                                                                                                              |
+====+==============+===========+==========================================+==================================================================================================================================+
| 0  | -0.054067254 | 0.9473684 | ___________________in five business days | Datetime(DatetimeOutput { moment: 2020-03-29T00:00:00+01:00, grain: Day, precision: Exact, latent: false, datetime_kind: Date }) |
+----+--------------+-----------+------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
```

Spanish:
```
Running `rustling-ontology/target/debug/rustling-cli --lang es parse 'por favor espere quince días hábiles'`
+----+--------------+-----------+--------------------------------------+------------------------------------------------------------------------+
| ix | log(p)       | p         | text                                 | Output(OutputValue)                                                    |
+====+==============+===========+======================================+========================================================================+
| 0  | -0.022041995 | 0.9781992 | _________________quince días hábiles | Duration(DurationOutput { period: Period({4: 15}), precision: Exact }) |
+----+--------------+-----------+--------------------------------------+------------------------------------------------------------------------+
```

Compared to a non-modified language:

```
Running `rustling-ontology/target/debug/rustling-cli --lang de parse 'warten sie bitte nur zwei werktage'`
+----+--------+---+------------------------------------+---------------------------+
| ix | log(p) | p | text                               | Output(OutputValue)       |
+====+========+===+====================================+===========================+
| 0  | 0      | 1 | _____________________zwei_________ | Integer(IntegerOutput(2)) |
+----+--------+---+------------------------------------+---------------------------+
```